### PR TITLE
Feature/#315 añadir creditos centro

### DIFF
--- a/src/main/java/com/nailing/app/centro/Centro.java
+++ b/src/main/java/com/nailing/app/centro/Centro.java
@@ -70,12 +70,39 @@ public class Centro {
 	@Column(name = "creditosrestantes")
 	@NotNull
 	private Integer creditosrestantes;
-	@Column(name = "citascreditos")
+	@Column(name = "pagado")
 	@NotNull
-	private Integer citasconcreditos;
-	@Column(name = "citassincreditos")
-	@NotNull
-	private Integer citassincreditos;
+	private Boolean pagado;
+
+	
+
+	public Centro(Long id, @Size(max = 1000) @NotBlank String nombre, @Size(max = 1000) @NotBlank String imagen,
+			@Size(max = 50) @NotBlank String provincia, LocalTime aperturaAM, LocalTime cierreAM, LocalTime aperturaPM,
+			LocalTime cierrePM, @NotNull Suscripcion suscripcion, @NotNull LocalDate ultimaSuscripcion,
+			@NotNull Integer creditosrestantes, @NotNull Boolean pagado) {
+		super();
+		this.id = id;
+		this.nombre = nombre;
+		this.imagen = imagen;
+		this.provincia = provincia;
+		this.aperturaAM = aperturaAM;
+		this.cierreAM = cierreAM;
+		this.aperturaPM = aperturaPM;
+		this.cierrePM = cierrePM;
+		this.suscripcion = suscripcion;
+		this.ultimaSuscripcion = ultimaSuscripcion;
+		this.creditosrestantes = creditosrestantes;
+		this.pagado = pagado;
+	}
+
+	public Boolean getPagado() {
+		return pagado;
+	}
+
+	public void setPagado(Boolean pagado) {
+		this.pagado = pagado;
+	}
+
 	public LocalDate getUltimaSuscripcion() {
 		return ultimaSuscripcion;
 	}
@@ -92,59 +119,12 @@ public class Centro {
 		this.creditosrestantes = creditosrestantes;
 	}
 
-	public Integer getCitasconcreditos() {
-		return citasconcreditos;
-	}
-
-	public void setCitasconcreditos(Integer citasconcreditos) {
-		this.citasconcreditos = citasconcreditos;
-	}
-
-	public Integer getCitassincreditos() {
-		return citassincreditos;
-	}
-
-	public void setCitassincreditos(Integer citassincreditos) {
-		this.citassincreditos = citassincreditos;
-	}
-
-	public Centro(Long id, @Size(max = 1000) @NotBlank String nombre, @Size(max = 1000) @NotBlank String imagen,
-			@Size(max = 50) @NotBlank String provincia, LocalTime aperturaAM, LocalTime cierreAM, LocalTime aperturaPM,
-			LocalTime cierrePM, @NotNull Suscripcion suscripcion, @NotNull LocalDate ultimaSuscripcion,
-			@NotNull Integer creditosrestantes, @NotNull Integer citasconcreditos, @NotNull Integer citassincreditos) {
-		super();
-		this.id = id;
-		this.nombre = nombre;
-		this.imagen = imagen;
-		this.provincia = provincia;
-		this.aperturaAM = aperturaAM;
-		this.cierreAM = cierreAM;
-		this.aperturaPM = aperturaPM;
-		this.cierrePM = cierrePM;
-		this.suscripcion = suscripcion;
-		this.ultimaSuscripcion = ultimaSuscripcion;
-		this.creditosrestantes = creditosrestantes;
-		this.citasconcreditos = citasconcreditos;
-		this.citassincreditos = citassincreditos;
-	}
+	
 
 	public Centro() {
 	}
 
-	public Centro(Long id, @Size(max = 1000) @NotBlank String nombre, @Size(max = 1000) @NotBlank String imagen,
-			String provincia, LocalTime aperturaAM, LocalTime cierreAM, LocalTime aperturaPM, LocalTime cierrePM, Suscripcion suscripcion) {
-		super();
-		this.id = id;
-		this.nombre = nombre;
-		this.imagen = imagen;
-		this.provincia = provincia;
-		this.aperturaAM = aperturaAM;
-		this.cierreAM = cierreAM;
-		this.aperturaPM = aperturaPM;
-		this.cierrePM = cierrePM;
-		this.suscripcion = suscripcion;
-	}
-
+	
 	public Long getId() {
 		return id;
 	}
@@ -241,7 +221,8 @@ public class Centro {
 	public String toString() {
 		return "Centro [id=" + id + ", nombre=" + nombre + ", imagen=" + imagen + ", provincia=" + provincia
 				+ ", aperturaAM=" + aperturaAM + ", cierreAM=" + cierreAM + ", aperturaPM=" + aperturaPM + ", cierrePM="
-				+ cierrePM +", suscripcion="+ suscripcion +"]";
+				+ cierrePM + ", suscripcion=" + suscripcion + ", ultimaSuscripcion=" + ultimaSuscripcion
+				+ ", creditosrestantes=" + creditosrestantes + ", pagado=" + pagado + "]";
 	}
 
 }

--- a/src/main/java/com/nailing/app/centro/Centro.java
+++ b/src/main/java/com/nailing/app/centro/Centro.java
@@ -18,6 +18,7 @@ import javax.validation.constraints.Size;
 
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+import java.time.LocalDate;
 import java.time.LocalTime;
 
 /**
@@ -63,6 +64,69 @@ public class Centro {
 	@Column(name = "suscripcion")
 	@NotNull
 	private Suscripcion suscripcion;
+	@Column(name = "ultimasuscripcion")
+	@NotNull
+	private LocalDate ultimaSuscripcion;
+	@Column(name = "creditosrestantes")
+	@NotNull
+	private Integer creditosrestantes;
+	@Column(name = "citascreditos")
+	@NotNull
+	private Integer citasconcreditos;
+	@Column(name = "citassincreditos")
+	@NotNull
+	private Integer citassincreditos;
+	public LocalDate getUltimaSuscripcion() {
+		return ultimaSuscripcion;
+	}
+
+	public void setUltimaSuscripcion(LocalDate ultimaSuscripcion) {
+		this.ultimaSuscripcion = ultimaSuscripcion;
+	}
+
+	public Integer getCreditosrestantes() {
+		return creditosrestantes;
+	}
+
+	public void setCreditosrestantes(Integer creditosrestantes) {
+		this.creditosrestantes = creditosrestantes;
+	}
+
+	public Integer getCitasconcreditos() {
+		return citasconcreditos;
+	}
+
+	public void setCitasconcreditos(Integer citasconcreditos) {
+		this.citasconcreditos = citasconcreditos;
+	}
+
+	public Integer getCitassincreditos() {
+		return citassincreditos;
+	}
+
+	public void setCitassincreditos(Integer citassincreditos) {
+		this.citassincreditos = citassincreditos;
+	}
+
+	public Centro(Long id, @Size(max = 1000) @NotBlank String nombre, @Size(max = 1000) @NotBlank String imagen,
+			@Size(max = 50) @NotBlank String provincia, LocalTime aperturaAM, LocalTime cierreAM, LocalTime aperturaPM,
+			LocalTime cierrePM, @NotNull Suscripcion suscripcion, @NotNull LocalDate ultimaSuscripcion,
+			@NotNull Integer creditosrestantes, @NotNull Integer citasconcreditos, @NotNull Integer citassincreditos) {
+		super();
+		this.id = id;
+		this.nombre = nombre;
+		this.imagen = imagen;
+		this.provincia = provincia;
+		this.aperturaAM = aperturaAM;
+		this.cierreAM = cierreAM;
+		this.aperturaPM = aperturaPM;
+		this.cierrePM = cierrePM;
+		this.suscripcion = suscripcion;
+		this.ultimaSuscripcion = ultimaSuscripcion;
+		this.creditosrestantes = creditosrestantes;
+		this.citasconcreditos = citasconcreditos;
+		this.citassincreditos = citassincreditos;
+	}
 
 	public Centro() {
 	}

--- a/src/main/java/com/nailing/app/centro/CentroController.java
+++ b/src/main/java/com/nailing/app/centro/CentroController.java
@@ -10,6 +10,8 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.CrossOrigin;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -34,6 +36,7 @@ import com.nailing.app.usuario.UsuarioService;
 @RestController
 @CrossOrigin(origins = "*", methods = { RequestMethod.GET, RequestMethod.POST, RequestMethod.DELETE })
 @RequestMapping("/centros")
+@EnableScheduling
 public class CentroController {
     
     @Autowired
@@ -85,4 +88,11 @@ public class CentroController {
         }
        
     }
+    @Operation(summary = "Llamada automatica para comprobación de centros")
+    @Scheduled(fixedRate = 86400000)
+    @GetMapping("/comprobacionCentros")
+    public void comprobacionCentros() {
+    	centroService.comprobacionCentros();
+    }
+    
 }

--- a/src/main/java/com/nailing/app/centro/CentroService.java
+++ b/src/main/java/com/nailing/app/centro/CentroService.java
@@ -4,6 +4,7 @@
  */
 package com.nailing.app.centro;
 
+import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -93,10 +94,35 @@ public class CentroService {
   
     public Centro addCentro(Centro centro) {
         if(centro != null){
+        	if(centro.getSuscripcion() == Suscripcion.BASIC){
+        		centro.setCreditosrestantes(150);
+        	}
+        	else if(centro.getSuscripcion() == Suscripcion.MEDIUM){
+        		centro.setCreditosrestantes(200);
+        	}
+        	else if(centro.getSuscripcion() == Suscripcion.ADVANCED){
+        		centro.setCreditosrestantes(300);
+        	}
+        	else if(centro.getSuscripcion() == Suscripcion.PREMIUM){
+        		centro.setCreditosrestantes(400);
+        	}
+        	centro.setCitasconcreditos(0);
+        	centro.setCitassincreditos(0);
             return centroRepository.save(centro);
         }else{
             throw new IllegalArgumentException();
         }
+    }
+    public Boolean fechacumplida(Centro centro) {
+    	Boolean result = null;
+    	LocalDate fechaActual = LocalDate.now();
+    	int dia = fechaActual.getDayOfMonth();
+    	LocalDate fechaSuscripcion = centro.getUltimaSuscripcion();
+    	int diaSuscripcion = fechaSuscripcion.getDayOfMonth();
+    	if(dia == diaSuscripcion) {
+    		
+    	}
+    	return result;
     }
   
     public Usuario asociarCentroUsuario(Usuario usuario, Centro centro) {

--- a/src/main/java/com/nailing/app/centro/CentroService.java
+++ b/src/main/java/com/nailing/app/centro/CentroService.java
@@ -94,7 +94,9 @@ public class CentroService {
   
     public Centro addCentro(Centro centro) {
         if(centro != null){
-		        if(!(centro.getPagado()== false)) {
+        	if(!(centroTieneCambios(centro)==true)) {
+        		if(!(centro.getPagado()== false)) {
+		        	centro.setUltimaSuscripcion(LocalDate.now());
 		        	if(centro.getSuscripcion() == Suscripcion.BASIC){
 		        		centro.setCreditosrestantes(150);
 		        	}
@@ -107,10 +109,11 @@ public class CentroService {
 		        	else if(centro.getSuscripcion() == Suscripcion.PREMIUM){
 		        		centro.setCreditosrestantes(400);
 		        	}
-		            
+        	}     
 		        }else {
 		        	
 		        }
+		    
 	        return centroRepository.save(centro);
         }else{
             throw new IllegalArgumentException();
@@ -118,10 +121,8 @@ public class CentroService {
     }
     public void fechacumplida(Centro centro) {
     	LocalDate fechaActual = LocalDate.now();
-    	int dia = fechaActual.getDayOfMonth();
     	LocalDate fechaSuscripcion = centro.getUltimaSuscripcion();
-    	int diaSuscripcion = fechaSuscripcion.getDayOfMonth();
-    	if(dia == diaSuscripcion) {
+    	if(fechaSuscripcion.plusMonths(1) == fechaActual) {
     		centro.setPagado(false);
     	}
     }
@@ -137,5 +138,34 @@ public class CentroService {
         usuario.setRol(Authorities.OWNER);
     	return usuarioService.save(usuario);
     }
-   
+   private Boolean centroTieneCambios(Centro centro) {
+	   List<Centro> centros = findAll();
+	   Boolean result = false;
+	   for(Centro c: centros) {
+		   if(c.getId() == centro.getId()) {
+			   if(c.getNombre() != c.getNombre()) {
+				   result = true;
+				   
+			   }
+			   else if(c.getImagen() != centro.getImagen()) {
+				   result = true;
+				  
+			   }
+			   else if(c.getAperturaAM() != centro.getAperturaAM()) {
+				   result = true;
+				 
+			   }
+			   else if(c.getAperturaPM() != centro.getAperturaPM()) {
+				   result = true;
+			   }
+			   else if(c.getCierreAM() != centro.getCierreAM()) {
+				   result = true;
+			   }
+			   else if(c.getCierrePM() != centro.getCierrePM()) {
+				   result = true;
+			   }
+		   }
+	   }
+	   return result;
+   }
 }

--- a/src/main/java/com/nailing/app/centro/CentroService.java
+++ b/src/main/java/com/nailing/app/centro/CentroService.java
@@ -94,35 +94,41 @@ public class CentroService {
   
     public Centro addCentro(Centro centro) {
         if(centro != null){
-        	if(centro.getSuscripcion() == Suscripcion.BASIC){
-        		centro.setCreditosrestantes(150);
-        	}
-        	else if(centro.getSuscripcion() == Suscripcion.MEDIUM){
-        		centro.setCreditosrestantes(200);
-        	}
-        	else if(centro.getSuscripcion() == Suscripcion.ADVANCED){
-        		centro.setCreditosrestantes(300);
-        	}
-        	else if(centro.getSuscripcion() == Suscripcion.PREMIUM){
-        		centro.setCreditosrestantes(400);
-        	}
-        	centro.setCitasconcreditos(0);
-        	centro.setCitassincreditos(0);
-            return centroRepository.save(centro);
+		        if(!(centro.getPagado()== false)) {
+		        	if(centro.getSuscripcion() == Suscripcion.BASIC){
+		        		centro.setCreditosrestantes(150);
+		        	}
+		        	else if(centro.getSuscripcion() == Suscripcion.MEDIUM){
+		        		centro.setCreditosrestantes(200);
+		        	}
+		        	else if(centro.getSuscripcion() == Suscripcion.ADVANCED){
+		        		centro.setCreditosrestantes(300);
+		        	}
+		        	else if(centro.getSuscripcion() == Suscripcion.PREMIUM){
+		        		centro.setCreditosrestantes(400);
+		        	}
+		            
+		        }else {
+		        	
+		        }
+	        return centroRepository.save(centro);
         }else{
             throw new IllegalArgumentException();
         }
     }
-    public Boolean fechacumplida(Centro centro) {
-    	Boolean result = null;
+    public void fechacumplida(Centro centro) {
     	LocalDate fechaActual = LocalDate.now();
     	int dia = fechaActual.getDayOfMonth();
     	LocalDate fechaSuscripcion = centro.getUltimaSuscripcion();
     	int diaSuscripcion = fechaSuscripcion.getDayOfMonth();
     	if(dia == diaSuscripcion) {
-    		
+    		centro.setPagado(false);
     	}
-    	return result;
+    }
+    public void comprobacionCentros() {
+    	for(Centro c : findAll()) {
+    		fechacumplida(c);
+    	}
     }
   
     public Usuario asociarCentroUsuario(Usuario usuario, Centro centro) {
@@ -131,4 +137,5 @@ public class CentroService {
         usuario.setRol(Authorities.OWNER);
     	return usuarioService.save(usuario);
     }
+   
 }

--- a/src/main/java/com/nailing/app/centro/CentroService.java
+++ b/src/main/java/com/nailing/app/centro/CentroService.java
@@ -122,7 +122,7 @@ public class CentroService {
     public void fechacumplida(Centro centro) {
     	LocalDate fechaActual = LocalDate.now();
     	LocalDate fechaSuscripcion = centro.getUltimaSuscripcion();
-    	if(fechaSuscripcion.plusMonths(1) == fechaActual) {
+    	if(fechaSuscripcion.plusMonths(1).isAfter(fechaActual) ) {
     		centro.setPagado(false);
     	}
     }

--- a/src/main/java/com/nailing/app/cita/CitaController.java
+++ b/src/main/java/com/nailing/app/cita/CitaController.java
@@ -90,6 +90,7 @@ public class CitaController {
 		Cita cita = null;
 		try {
 			cita = citaService.addCita(ids);
+			citaService.restaruncredito(cita);
 			return new ResponseEntity<>(cita, HttpStatus.CREATED);
 		} catch (IllegalArgumentException e) {
 			return new ResponseEntity<>(cita, HttpStatus.BAD_REQUEST);

--- a/src/main/java/com/nailing/app/cita/CitaController.java
+++ b/src/main/java/com/nailing/app/cita/CitaController.java
@@ -90,7 +90,6 @@ public class CitaController {
 		Cita cita = null;
 		try {
 			cita = citaService.addCita(ids);
-			citaService.restaruncredito(cita);
 			return new ResponseEntity<>(cita, HttpStatus.CREATED);
 		} catch (IllegalArgumentException e) {
 			return new ResponseEntity<>(cita, HttpStatus.BAD_REQUEST);

--- a/src/main/java/com/nailing/app/cita/CitaService.java
+++ b/src/main/java/com/nailing/app/cita/CitaService.java
@@ -132,19 +132,11 @@ public class CitaService {
 
 		Cita cita = new Cita(precio, horaInicio, horaFin, decoracion, acabado, base, tipo, disenyo, tamanyo, forma,
 				usuario, centro);
-
-		return citaRepository.save(cita);
-
-	}
-	public void restaruncredito(Cita cita) {
 		Centro citacentro = cita.getCentro();
-		if(citacentro.getCreditosrestantes()>0) {
-			citacentro.setCreditosrestantes(citacentro.getCreditosrestantes()-1);
-			citacentro.setCitasconcreditos(citacentro.getCitasconcreditos()+1);
-		}else {
-			citacentro.setCitassincreditos(citacentro.getCitassincreditos()+1);
-		}
+		citacentro.setCreditosrestantes(citacentro.getCreditosrestantes()-1);
+		return citaRepository.save(cita);
 	}
+	
 
 	public List<String> findDisponibles(String fecha, Integer tiempo, Long centroId) {
 		DateTimeFormatter dt = DateTimeFormatter.ofPattern("yyyy-MM-dd HH");

--- a/src/main/java/com/nailing/app/cita/CitaService.java
+++ b/src/main/java/com/nailing/app/cita/CitaService.java
@@ -136,6 +136,15 @@ public class CitaService {
 		return citaRepository.save(cita);
 
 	}
+	public void restaruncredito(Cita cita) {
+		Centro citacentro = cita.getCentro();
+		if(citacentro.getCreditosrestantes()>0) {
+			citacentro.setCreditosrestantes(citacentro.getCreditosrestantes()-1);
+			citacentro.setCitasconcreditos(citacentro.getCitasconcreditos()+1);
+		}else {
+			citacentro.setCitassincreditos(citacentro.getCitassincreditos()+1);
+		}
+	}
 
 	public List<String> findDisponibles(String fecha, Integer tiempo, Long centroId) {
 		DateTimeFormatter dt = DateTimeFormatter.ofPattern("yyyy-MM-dd HH");

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -24,9 +24,9 @@ DELETE FROM acabado;
 DELETE FROM centro;
  
 ------------------------------------------CENTROS---------------------------------------------
-INSERT INTO centro (id, apertura_am, cierre_am, apertura_pm, cierre_pm, imagen, nombre, provincia, suscripcion) VALUES (1, '09:00:00','13:00:00','16:00:00','21:00:00', 'https://i.ibb.co/qkFKLsm/F253-E9-DA-6780-4-A9-D-9-EAB-804784-BBEE21.jpg', 'Nails by Claudia', 'Málaga',0);
-INSERT INTO centro (id, apertura_am, cierre_am, apertura_pm, cierre_pm, imagen, nombre, provincia, suscripcion) VALUES (2, '08:30:00','13:00:00','16:00:00','20:30:00', 'https://i.ibb.co/WP2MvVS/867-F548-A-5074-4-C98-AE6-D-F48083-CEE8-E9.jpg', 'Más guapa que la novia', 'Sevilla',2);
-INSERT INTO centro (id, apertura_am, cierre_am, apertura_pm, cierre_pm, imagen, nombre, provincia, suscripcion) VALUES (3, '09:30:00','13:00:00','16:00:00','21:30:00', 'https://i.ibb.co/wdhjNNf/8-DF66-CD3-3-E2-D-4-C37-B96-A-247-E3-D5-B221-B.png', 'Nails by Verónica', 'Cádiz',3);
+INSERT INTO centro (id, apertura_am, cierre_am, apertura_pm, cierre_pm, imagen, nombre, provincia, suscripcion,ultimasuscripcion, creditosRestantes, pagado) VALUES (1, '09:00:00','13:00:00','16:00:00','21:00:00', 'https://i.ibb.co/qkFKLsm/F253-E9-DA-6780-4-A9-D-9-EAB-804784-BBEE21.jpg', 'Nails by Claudia', 'Málaga',0, '07/04/2022',150,true);
+INSERT INTO centro (id, apertura_am, cierre_am, apertura_pm, cierre_pm, imagen, nombre, provincia, suscripcion,ultimasuscripcion, creditosRestantes, pagado) VALUES (2, '08:30:00','13:00:00','16:00:00','20:30:00', 'https://i.ibb.co/WP2MvVS/867-F548-A-5074-4-C98-AE6-D-F48083-CEE8-E9.jpg', 'Más guapa que la novia', 'Sevilla',2,'14/04/2022',300, true);
+INSERT INTO centro (id, apertura_am, cierre_am, apertura_pm, cierre_pm, imagen, nombre, provincia, suscripcion,ultimasuscripcion, creditosRestantes, pagado) VALUES (3, '09:30:00','13:00:00','16:00:00','21:30:00', 'https://i.ibb.co/wdhjNNf/8-DF66-CD3-3-E2-D-4-C37-B96-A-247-E3-D5-B221-B.png', 'Nails by Verónica', 'Cádiz',3,'17/03/2022',400,true);
 
 ----------------------------------------------TIPOS----------------------------------------------
 --CENTRO 1--


### PR DESCRIPTION
Se finaliza la funcionalidad de añadir créditos a centros.
1) Si se crea una cita, se resta 1 crédito al centro
2) Si se crea/actualiza un centro, se añaden los créditos correspondientes a la suscripción
3) Respecto al pago: desde frontend se realiza la comprobación de los pagos tanto de créditos en negativo  como dl pago por suscripción